### PR TITLE
Using reselect for sites data on All Sites page

### DIFF
--- a/client/content/sites/data/duck/interfaces/IJobData.ts
+++ b/client/content/sites/data/duck/interfaces/IJobData.ts
@@ -1,0 +1,5 @@
+import IJobInfo from "../../../../../models/jobs/IJobInfo";
+
+export default interface IJobData {
+    [jobId: string]: IJobInfo;
+}

--- a/client/content/sites/data/duck/interfaces/ISiteData.ts
+++ b/client/content/sites/data/duck/interfaces/ISiteData.ts
@@ -1,0 +1,5 @@
+import ISiteInfo from "../../../../../models/sites/ISiteInfo";
+
+export default interface ISiteData {
+    [siteId: string]: ISiteInfo;
+}

--- a/client/content/sites/data/duck/interfaces/ISitesDataState.ts
+++ b/client/content/sites/data/duck/interfaces/ISitesDataState.ts
@@ -1,7 +1,7 @@
-import IJobInfo from "../../../../../models/jobs/IJobInfo";
-import ISiteInfo from "../../../../../models/sites/ISiteInfo";
+import IJobData from "./IJobData";
+import ISiteData from "./ISiteData";
 
 export default interface ISitesDataState {
-    sites: { [siteId: string]: ISiteInfo };
-    jobs: { [jobId: string]: IJobInfo };
+    sites: ISiteData;
+    jobs: IJobData;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8673,6 +8673,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
+    },
     "resolve": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react-router-dom": "^4.2.2",
     "redux-logger": "^3.0.6",
     "redux-promise-middleware": "^5.1.1",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "reselect": "^3.0.1"
   },
   "devDependencies": {
     "@types/prop-types": "^15.5.3",


### PR DESCRIPTION
I noticed that the computation for converting ISiteInfo into DetailsListItems for the AllSites component was occurring for every action. This is ridiculous especially when nothing has changed. Thankfully reselect helps with that where it will memoize the computed data given a certain state elements and will only recompute if those said state elements have changed.